### PR TITLE
tools: use pytorch/nnAudio for data preparation's CQT

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ See https://ar5iv.labs.arxiv.org/html/2306.09025 for the July 2023 research pape
     1. Apple computer with an Apple M-series chip
     2. Other computer with an Nvidia GPU (including free cloud options like Google Colab)
 2. python3 (minimum version 3.10, tested on 3.11) with these libraries:
-    1. torch (compiled with CUDA or MPS or other GPU support as appropriate for your hardware)
+    1. torch torchaudio (compiled with CUDA or MPS or other GPU support as appropriate for your hardware)
     2. librosa
-    3. Optional: tensorboard
+    3. nnAudio
+    4. Optional: tensorboard
 3. sox
 
 # Usage

--- a/data/covers80/hparams.yaml
+++ b/data/covers80/hparams.yaml
@@ -6,6 +6,7 @@
   "name": "cqt_with_asr_noise",
   "noise_path": "dataset/asr_as_noise/dataset.txt"
 }
+"device": "mps"
 "train-sample_data_split": 0.1 # percent of training data to reserve for validation aka "train-sample"
 "train-sample_unseen": 0.02 # percent of song_ids from training data to reserve exclusively for validation aka "train-sample"
 "test_data_split": 0.1 # percent of training data to reserve for test aka "dev"

--- a/data/covers80_testset/hparams.yaml
+++ b/data/covers80_testset/hparams.yaml
@@ -1,3 +1,4 @@
+"device": "mps"
 "aug_speed_mode": [1.0]
 "train-sample_data_split": 0 # percent of training data to reserve for validation aka "train-sample"
 "train-sample_unseen": 0 # percent of song_ids from training data to reserve exclusively for validation aka "train-sample"


### PR DESCRIPTION
Reduce the data preparation CQT step duration using nnAudio's implementation.

$ time python3 -m tools.extract_csi_features data/covers80_testset
before:
real    1m31,340s
user    17m35,827s
sys     0m10,517s

after (with cuda):
real    0m10,519s
user    1m33,332s
sys     0m10,304s

A new device parameter is added to data/covers80_testset/hparams.yaml to select the device, similar to the train parameter. It is not ideal, but when I tried auto-detection of the device, I faced this error:
> Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
It can be improved later.

The librosa implementation is kept as it is faster when the device is set to "cpu".